### PR TITLE
Add a non straw-man linked list.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -8,4 +8,6 @@ add_executable(strbench main.c
         ll.h
         ll.c
         str.h
-        str.c)
+        str.c
+	arena.h
+	list.h)

--- a/arena.h
+++ b/arena.h
@@ -1,0 +1,34 @@
+typedef struct {
+  char* memory;
+  long  used;
+} Arena;
+
+// Reserve a huge amount of the address space.
+// Since this program also uses malloc, we can't reserve
+// the whole address space, so the reccomended value is 64 GB.
+static void arena_initialize(Arena* arena, long size) {
+  // Windows equvalent of mmap: VirtualAlloc
+  int   protection = PROT_READ   | PROT_WRITE;
+  int   flags      = MAP_PRIVATE | MAP_ANONYMOUS;
+  char* memory     = mmap(NULL, size, protection, flags, -1, 0);
+  assert(memory != MAP_FAILED);
+
+  arena->memory = memory;
+  arena->used   = 0;
+}
+
+static char* arena_allocate_bytes(Arena* arena, long bytes_size) {
+  // Mac and Linux will commit the memory on the next page fault.
+  // To expicitly commit the memory, use `mprotect` on Mac/Linux and
+  // `VirtualAlloc` on Windows.
+  char* result  = &arena->memory[arena->used];
+  arena->used  += bytes_size;
+  return result;
+}
+
+#define arena_allocate(arena, type) \
+  ((type*) arena_allocate_bytes((arena), sizeof(type)))
+
+static void arena_clear(Arena* arena) {
+  arena->used = 0;
+}

--- a/list.h
+++ b/list.h
@@ -1,0 +1,69 @@
+typedef struct ListNode ListNode;
+typedef struct List     List;
+
+#define MEMORY_SIZE (8 * 1024 * 1024 - 8)
+
+struct ListNode {
+  long      used;
+  ListNode* next;
+  char      memory[MEMORY_SIZE];
+};
+
+// `head` and `tail` may be null.
+struct List {
+  ListNode* head;
+  ListNode* tail;
+};
+
+// bytes_size must be less than or equal to MEMORY_SIZE
+static char* list_push_bytes(List* list, Arena* arena, long bytes_size) {
+  if (list->head == NULL) {
+    ListNode* new_head = arena_allocate(arena, ListNode);
+    new_head->used     = 0;
+    new_head->next     = NULL;
+    list->head         = new_head;
+    list->tail         = new_head;
+  }
+
+  ListNode* tail = list->tail;
+  if (bytes_size > sizeof tail->memory - tail->used) {
+    ListNode* new_tail = arena_allocate(arena, ListNode);
+    new_tail->used     = bytes_size;
+    new_tail->next     = NULL;
+    list->tail         = new_tail;
+    return new_tail->memory;
+  }
+
+  char* result  = &tail->memory[tail->used];
+  tail->used   += bytes_size;
+  return result;
+}
+
+// Free a list by reverting arena `used` to before we started allocating.
+// If you have competing lifetimes on the arena, use a slab allocator.
+
+static void list_memset(List* list, int value) {
+  for (ListNode* i = list->head; i != NULL; i = i->next) {
+    memset(i->memory, value, i->used);
+  }
+}
+
+static void list_strcat(List* a, List* b) {
+  a->tail->next = b->head;
+  a->tail       = b->tail;
+}
+
+static void listbench(Arena* arena, long size) {
+  List a = {};
+  List b = {};
+  while (size > 0) {
+    list_push_bytes(&a, arena, min(size, MEMORY_SIZE));
+    list_push_bytes(&b, arena, min(size, MEMORY_SIZE));
+    size -= MEMORY_SIZE;
+  }
+
+  list_memset(&a, 'a');
+  list_memset(&b, 'b');
+  list_strcat(&a, &b);
+  arena_clear(arena);
+}

--- a/main.c
+++ b/main.c
@@ -1,11 +1,17 @@
+#include <assert.h>
 #include <stdio.h>
+#include <string.h>
 #include <time.h>
+#include <sys/mman.h>
 
+#define min(a, b) (((a) < (b)) ? (a) : (b))
+
+#include "arena.h"
+#include "list.h"
 #include "ll.h"
 #include "str.h"
 
-
-void benchmark(const unsigned int size) {
+void benchmark(Arena* arena, const unsigned int size) {
     clock_t start, end;
     double runtime;
     printf("\n\n=== Benchmarking linked list vs contiguous memory, size: %u ===\n\n", size);
@@ -21,10 +27,21 @@ void benchmark(const unsigned int size) {
     end = clock();
     runtime = (double)(end - start) / CLOCKS_PER_SEC / BENCHMARK_ITERS;
     printf("Contiguous memory:\t\t%0.3f msec/iter\n", runtime * 1000);
+
+    start = clock();
+    for (int i = 0; i < BENCHMARK_ITERS; i++) listbench(arena, size);
+    end = clock();
+    printf("List Clock Start: %lu\n", start);
+    printf("List Clock End: %lu\n", end);
+    runtime = (double)(end - start) / CLOCKS_PER_SEC / BENCHMARK_ITERS;
+    printf("List memory:\t\t\t%0.3f msec/iter\n", runtime * 1000);
 }
 
 int main() {
-    benchmark(100);
-    benchmark(1000);
-    benchmark(5000);
+    Arena arena;
+    arena_initialize(&arena, 1ll << 36);
+  
+    benchmark(&arena, 100);
+    benchmark(&arena, 1000);
+    benchmark(&arena, 5000);
 }


### PR DESCRIPTION
Here are the results on my computer:
Note that I print the clock start and end because the execution time is too small to be captured by the msec statistic. This microbenchmark  workload is favorable to the linked list, so this is a bit inflated but I also see the same results in practice.

=== Benchmarking linked list vs contiguous memory, size: 100 ===

Linked List:			0.026 msec/iter
Contiguous memory:		0.021 msec/iter
List Clock Start: 474844
List Clock End: 474977
List memory:			0.000 msec/iter


=== Benchmarking linked list vs contiguous memory, size: 1000 ===

Linked List:			0.292 msec/iter
Contiguous memory:		0.227 msec/iter
List Clock Start: 5668086
List Clock End: 5668364
List memory:			0.000 msec/iter


=== Benchmarking linked list vs contiguous memory, size: 5000 ===

Linked List:			1.922 msec/iter
Contiguous memory:		1.207 msec/iter
List Clock Start: 36964658
List Clock End: 36965636
List memory:			0.000 msec/iter